### PR TITLE
Add CLI binary and Node.js engine requirement in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "@swrpg-online/dice",
-      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@types/jest": "^29.5.14",
@@ -14,6 +13,9 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.2"
+      },
+      "bin": {
+        "swrpg-dice": "dist/cli.js"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -24,6 +26,9 @@
         "lint-staged": "^15.2.10",
         "prettier": "3.4.1",
         "semantic-release": "^24.2.0"
+      },
+      "engines": {
+        "node": ">=21"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
## Summary
- Adds a CLI binary entry point for the package
- Specifies Node.js engine version requirement (>=21)
- Removes explicit version field from package-lock.json root

## Changes

### Package Configuration
- Added `bin` field pointing to `dist/cli.js` as `swrpg-dice` CLI command
- Added `engines` field specifying Node.js version >=21
- Removed the `version` field from the root package-lock.json to avoid conflicts or redundancy

## Test plan
- [ ] Verify that `swrpg-dice` CLI command is available after installation
- [ ] Confirm that the package enforces Node.js version >=21
- [ ] Run existing tests to ensure no regressions
- [ ] Validate package installation and usage in a Node.js >=21 environment

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/32a68963-aaab-4d2b-b83c-7ca4e33a956f