### PR TITLE
Fix Triumph and Despair Dice Face Symbols to Include Success and Failure

### DIFF
--- a/src/diceFaces.ts
+++ b/src/diceFaces.ts
@@ -52,7 +52,7 @@ export const PROFICIENCY_DIE_FACES: Record<number, DieFaceSymbols> = {
   9: { successes: 1, advantages: 1 }, // (S)(A)
   10: { advantages: 2 }, // (A)(A)
   11: { advantages: 2 }, // (A)(A)
-  12: { triumphs: 1 }, // (TR)
+  12: { triumphs: 1, successes: 1 }, // (TR) - Triumph also counts as Success
 };
 
 export const CHALLENGE_DIE_FACES: Record<number, DieFaceSymbols> = {
@@ -67,7 +67,7 @@ export const CHALLENGE_DIE_FACES: Record<number, DieFaceSymbols> = {
   9: { failures: 1, threats: 1 }, // (F)(TH)
   10: { threats: 2 }, // (TH)(TH)
   11: { threats: 2 }, // (TH)(TH)
-  12: { despairs: 1 }, // (D)
+  12: { despairs: 1, failures: 1 }, // (D) - Despair also counts as Failure
 };
 
 export const FORCE_DIE_FACES: Record<number, DieFaceSymbols> = {

--- a/tests/dice.test.ts
+++ b/tests/dice.test.ts
@@ -422,7 +422,7 @@ describe("SWRPG Dice Rolling", () => {
         [
           12,
           {
-            successes: 0,
+            successes: 1,
             failures: 0,
             advantages: 0,
             threats: 0,
@@ -791,7 +791,7 @@ describe("SWRPG Dice Rolling", () => {
           12,
           {
             successes: 0,
-            failures: 0,
+            failures: 1,
             advantages: 0,
             threats: 0,
             triumphs: 0,

--- a/tests/diceFaces.test.ts
+++ b/tests/diceFaces.test.ts
@@ -71,7 +71,7 @@ describe("Dice Face Configurations", () => {
       expect(PROFICIENCY_DIE_FACES[9]).toEqual({ successes: 1, advantages: 1 }); // (S)(A)
       expect(PROFICIENCY_DIE_FACES[10]).toEqual({ advantages: 2 }); // (A)(A)
       expect(PROFICIENCY_DIE_FACES[11]).toEqual({ advantages: 2 }); // (A)(A)
-      expect(PROFICIENCY_DIE_FACES[12]).toEqual({ triumphs: 1 }); // (TR)
+      expect(PROFICIENCY_DIE_FACES[12]).toEqual({ triumphs: 1, successes: 1 }); // (TR) - Triumph also counts as Success
     });
   });
 
@@ -88,7 +88,7 @@ describe("Dice Face Configurations", () => {
       expect(CHALLENGE_DIE_FACES[9]).toEqual({ failures: 1, threats: 1 }); // (F)(TH)
       expect(CHALLENGE_DIE_FACES[10]).toEqual({ threats: 2 }); // (TH)(TH)
       expect(CHALLENGE_DIE_FACES[11]).toEqual({ threats: 2 }); // (TH)(TH)
-      expect(CHALLENGE_DIE_FACES[12]).toEqual({ despairs: 1 }); // (D)
+      expect(CHALLENGE_DIE_FACES[12]).toEqual({ despairs: 1, failures: 1 }); // (D) - Despair also counts as Failure
     });
   });
 


### PR DESCRIPTION
## Summary
- Corrects the dice face definitions for Triumph and Despair in the proficiency and challenge dice respectively
- Ensures Triumph also counts as a Success
- Ensures Despair also counts as a Failure
- Updates related tests to reflect these changes

## Changes

### Dice Face Definitions
- Modified `PROFICIENCY_DIE_FACES[12]` to include `{ triumphs: 1, successes: 1 }` instead of just `{ triumphs: 1 }`
- Modified `CHALLENGE_DIE_FACES[12]` to include `{ despairs: 1, failures: 1 }` instead of just `{ despairs: 1 }`

### Tests
- Updated dice roll tests to expect 1 success when rolling a Triumph (12 on proficiency die)
- Updated dice roll tests to expect 1 failure when rolling a Despair (12 on challenge die)
- Updated dice face configuration tests to match the new definitions

## Test plan
- [x] Run unit tests for dice face configurations
- [x] Run dice roll tests to verify success and failure counts for Triumph and Despair
- [x] Confirm no regressions in other dice face behaviors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b889db95-41ad-4f04-82eb-299f937d8fdb