### PR TITLE
Fix automatic despair implicit failure counting and update tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "rollup": "^2.79.2",
         "rollup-plugin-terser": "^7.0.2",
         "semantic-release": "^24.2.0",
-        "ts-jest": "^29.4.1",
+        "ts-jest": "^29.4.4",
         "tslib": "^2.8.1",
         "typescript": "^5.7.2"
       },
@@ -10522,9 +10522,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
-      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
+      "version": "29.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
+      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "rollup": "^2.79.2",
     "rollup-plugin-terser": "^7.0.2",
     "semantic-release": "^24.2.0",
-    "ts-jest": "^29.4.1",
+    "ts-jest": "^29.4.4",
     "tslib": "^2.8.1",
     "typescript": "^5.7.2"
   },

--- a/src/dice.ts
+++ b/src/dice.ts
@@ -226,8 +226,8 @@ const sumResults = (
       darkSide: acc.darkSide + (curr.darkSide || 0),
     }),
     {
-      successes: automaticSymbols?.successes || 0,
-      failures: automaticSymbols?.failures || 0,
+      successes: (automaticSymbols?.successes || 0) + (automaticSymbols?.triumphs || 0),
+      failures: (automaticSymbols?.failures || 0) + (automaticSymbols?.despairs || 0),
       advantages: automaticSymbols?.advantages || 0,
       threats: automaticSymbols?.threats || 0,
       triumphs: automaticSymbols?.triumphs || 0,

--- a/tests/modifiers.test.ts
+++ b/tests/modifiers.test.ts
@@ -98,6 +98,64 @@ describe("Dice Pool Modifiers", () => {
       cleanup();
     });
 
+    test("automatic triumphs include implicit successes", () => {
+      const cleanup = mockMathRandom(0.1); // Low roll for minimal dice contribution
+      const pool: DicePool = {
+        automaticTriumphs: 2,
+      };
+
+      const result = roll(pool);
+
+      // Should have 2 triumphs and at least 2 successes (implicit)
+      expect(result.summary.triumphs).toBe(2);
+      expect(result.summary.successes).toBeGreaterThanOrEqual(2);
+      cleanup();
+    });
+
+    test("automatic despairs include implicit failures", () => {
+      const cleanup = mockMathRandom(0.1); // Low roll for minimal dice contribution
+      const pool: DicePool = {
+        automaticDespairs: 3,
+      };
+
+      const result = roll(pool);
+
+      // Should have 3 despairs and at least 3 failures (implicit)
+      expect(result.summary.despair).toBe(3);
+      expect(result.summary.failures).toBeGreaterThanOrEqual(3);
+      cleanup();
+    });
+
+    test("automatic triumphs add to existing successes", () => {
+      const cleanup = mockMathRandom(0.1);
+      const pool: DicePool = {
+        automaticSuccesses: 3,
+        automaticTriumphs: 2,
+      };
+
+      const result = roll(pool);
+
+      // Should have 2 triumphs and 5 total successes (3 explicit + 2 implicit from triumphs)
+      expect(result.summary.triumphs).toBe(2);
+      expect(result.summary.successes).toBe(5);
+      cleanup();
+    });
+
+    test("automatic despairs add to existing failures", () => {
+      const cleanup = mockMathRandom(0.1);
+      const pool: DicePool = {
+        automaticFailures: 2,
+        automaticDespairs: 1,
+      };
+
+      const result = roll(pool);
+
+      // Should have 1 despair and 3 total failures (2 explicit + 1 implicit from despair)
+      expect(result.summary.despair).toBe(1);
+      expect(result.summary.failures).toBe(3);
+      cleanup();
+    });
+
     test("adds automatic light side points to roll result", () => {
       const cleanup = mockMathRandom(0.5);
       const pool: DicePool = {


### PR DESCRIPTION
## Summary
- Corrects the counting of implicit successes and failures for automatic triumphs and despairs in dice rolls
- Updates package dependencies for ts-jest to version 29.4.4
- Adds comprehensive tests to verify the correct behavior of automatic triumphs and despairs affecting successes and failures

## Changes

### Core Functionality
- Adjusted dice result aggregation to include triumphs as implicit successes and despairs as implicit failures

### Testing
- Added multiple tests in `modifiers.test.ts` to ensure:
  - Automatic triumphs include implicit successes
  - Automatic despairs include implicit failures
  - Automatic triumphs add to existing successes
  - Automatic despairs add to existing failures

### Dependencies
- Updated `ts-jest` from 29.4.1 to 29.4.4 in `package.json` and `package-lock.json`

## Test plan
- [x] Run new and existing tests to confirm automatic triumphs and despairs correctly affect success and failure counts
- [x] Verify no regressions in dice roll behavior
- [x] Confirm dependency updates do not break test suite or build process

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/894b52aa-3546-4b03-a903-401f71e48bf3