### PR TITLE
fix: correct proficiency die face 11 to 2 advantages

### DIFF
--- a/src/diceFaces.ts
+++ b/src/diceFaces.ts
@@ -51,7 +51,7 @@ export const PROFICIENCY_DIE_FACES: Record<number, DieFaceSymbols> = {
   8: { successes: 1, advantages: 1 }, // (S)(A)
   9: { successes: 1, advantages: 1 }, // (S)(A)
   10: { advantages: 2 }, // (A)(A)
-  11: { successes: 1, advantages: 1 }, // (S)(A)
+  11: { advantages: 2 }, // (A)(A)
   12: { triumphs: 1 }, // (TR) - Triumph also counts as Success
 };
 

--- a/tests/dice.test.ts
+++ b/tests/dice.test.ts
@@ -409,9 +409,9 @@ describe("SWRPG Dice Rolling", () => {
         [
           11,
           {
-            successes: 1,
+            successes: 0,
             failures: 0,
-            advantages: 1,
+            advantages: 2,
             threats: 0,
             triumphs: 0,
             despair: 0,

--- a/tests/diceFaces.test.ts
+++ b/tests/diceFaces.test.ts
@@ -70,10 +70,7 @@ describe("Dice Face Configurations", () => {
       expect(PROFICIENCY_DIE_FACES[8]).toEqual({ successes: 1, advantages: 1 }); // (S)(A)
       expect(PROFICIENCY_DIE_FACES[9]).toEqual({ successes: 1, advantages: 1 }); // (S)(A)
       expect(PROFICIENCY_DIE_FACES[10]).toEqual({ advantages: 2 }); // (A)(A)
-      expect(PROFICIENCY_DIE_FACES[11]).toEqual({
-        successes: 1,
-        advantages: 1,
-      }); // (S)(A)
+      expect(PROFICIENCY_DIE_FACES[11]).toEqual({ advantages: 2 }); // (A)(A)
       expect(PROFICIENCY_DIE_FACES[12]).toEqual({ triumphs: 1 }); // (TR) - Triumph also counts as Success
     });
   });


### PR DESCRIPTION
## Summary

- Proficiency d12 face 11 was `{successes:1,advantages:1}` (1 success + 1 advantage), causing the die to have 4 (S)(A) faces and only 1 (A)(A) face.
- Per Fantasy Flight / Edge of the Empire, the canonical proficiency die distribution is **3 (S)(A) faces and 2 (A)(A) faces**. Updated face 11 to `{advantages:2}`.
- Fixed two tests in `tests/diceFaces.test.ts` and `tests/dice.test.ts` that codified the wrong value.

## Why this matters

This bug surfaced as user-reported tally errors in the `r011.swrpg.online` dice-roller app: when a proficiency die rolled 11, the rendered SVG correctly showed two advantage glyphs, but the summary added 1 success + 1 advantage, producing summaries that disagreed with the visible dice by ~1 symbol.

The same bad face data is bundled into `@swrpg-online/monte-carlo`, so its odds for proficiency-heavy pools are also slightly off. After this lands and a patch release goes out, monte-carlo can rebuild against the fixed dep.

## Test plan
- [x] `npm test` — all 254 tests pass
- [ ] Verify the new `3.0.x` release in the consuming app produces correct summaries on the original repro share URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)